### PR TITLE
feat: preserve diagnostics across multiple live checks

### DIFF
--- a/out/panels/WriteOffMenuPanel.js
+++ b/out/panels/WriteOffMenuPanel.js
@@ -225,24 +225,24 @@ class WriteOffMenuPanel {
             }
             if (command === "webviewLoaded") {
                 logger.info('WriteOffMenuPanel: Webview loaded message received');
-                const historyId = yield this._storageManager.getLastScanHistoryId();
-                logger.info('WriteOffMenuPanel: Last scan history ID: ' + historyId);
-                let lastScanIssues = null;
-                if (historyId !== null) {
-                    lastScanIssues = yield this._storageManager.getLastScanIssuesFromHistoryId(historyId);
-                    logger.info('WriteOffMenuPanel: Issues retrieved: ' + (lastScanIssues ? lastScanIssues.length : 'No issues'));
-                    if (lastScanIssues && lastScanIssues.length > 0) {
-                        logger.info('WriteOffMenuPanel: First issue sample: ' + JSON.stringify(lastScanIssues[0], null, 2));
+                let issues = [];
+                try {
+                    const history = yield this._storageManager.getLivecheckHistory();
+                    if (Array.isArray(history)) {
+                        for (const entry of history) {
+                            const path = require('path');
+                            const fileName = entry.path ? path.basename(entry.path) : undefined;
+                            for (const issue of entry.issues || []) {
+                                issues.push(Object.assign(Object.assign({}, issue), { historyId: entry.id, historyPath: entry.path, fileName: issue.fileName || fileName }));
+                            }
+                        }
                     }
                 }
-                else {
-                    logger.info('WriteOffMenuPanel: No history ID found');
+                catch (e) {
+                    logger.warn('WriteOffMenuPanel: getLivecheckHistory failed: ' + (e === null || e === void 0 ? void 0 : e.message));
                 }
-                // Create the data structure expected by the webview
-                const woData = {
-                    issues: lastScanIssues || [],
-                    historyId: historyId
-                };
+                logger.info('WriteOffMenuPanel: Total issues retrieved: ' + issues.length);
+                const woData = { issues: issues };
                 if (this._preselectIssue) {
                     woData.preselect = this._preselectIssue;
                 }

--- a/out/services/LocalStorageService.js
+++ b/out/services/LocalStorageService.js
@@ -120,7 +120,16 @@ class LocalStorageService {
                     });
                 }
                 if (row.issue_data) {
-                    historyMap.get(row.id).issues.push(JSON.parse(row.issue_data));
+                    const issue = JSON.parse(row.issue_data);
+                    try {
+                        const path = require('path');
+                        const fileName = row.path ? path.basename(row.path) : undefined;
+                        if (fileName && !issue.fileName) {
+                            issue.fileName = fileName;
+                        }
+                    }
+                    catch (_) { }
+                    historyMap.get(row.id).issues.push(issue);
                 }
             }
             stmt.free();
@@ -130,8 +139,10 @@ class LocalStorageService {
     setLivecheckHistory(path, issues, timestamp) {
         return __awaiter(this, void 0, void 0, function* () {
             const db = yield this.getDb();
+            db.run(`DELETE FROM Issues WHERE history_id IN (SELECT id FROM LivecheckHistory WHERE path = ?)`, [path]);
+            db.run(`DELETE FROM WriteOffData WHERE history_id IN (SELECT id FROM LivecheckHistory WHERE path = ?)`, [path]);
+            db.run(`DELETE FROM LivecheckHistory WHERE path = ?`, [path]);
             db.run(`INSERT INTO LivecheckHistory (path, timestamp) VALUES (?, ?)`, [path, timestamp]);
-            // Get last inserted id
             const stmt = db.prepare(`SELECT last_insert_rowid() as id`);
             stmt.step();
             const row = stmt.getAsObject();

--- a/out/services/MementoStorageService.js
+++ b/out/services/MementoStorageService.js
@@ -62,14 +62,16 @@ class MementoStorageService {
     setLivecheckHistory(path, issues, timestamp) {
         return __awaiter(this, void 0, void 0, function* () {
             const history = yield this.getLivecheckHistory();
-            const newId = history.length > 0 ? history[history.length - 1].id + 1 : 1;
-            history.push({
+            const filtered = history.filter(h => h.path !== path);
+            const maxId = filtered.reduce((max, h) => Math.max(max, h.id), 0);
+            const newId = maxId + 1;
+            filtered.push({
                 id: newId,
                 path,
                 timestamp,
                 issues,
             });
-            yield this.memento.update('LivecheckHistory', history);
+            yield this.memento.update('LivecheckHistory', filtered);
             return newId;
         });
     }

--- a/out/utilities/UpdateDiagnostics.js
+++ b/out/utilities/UpdateDiagnostics.js
@@ -25,10 +25,13 @@ const extension_1 = require("../extension");
 function updateDiagnostics(document, response, context, storageManager) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!document || !response) {
-            extension_1.collection.clear();
+            if (document) {
+                extension_1.collection.delete(document.uri);
+            }
             return;
         }
-        extension_1.collection.clear();
+        // Remove diagnostics only for this document
+        extension_1.collection.delete(document.uri);
         const diagnosticsArray = [];
         const displayOnlyBlockerIssues = (yield storageManager.getUserData('OnlyBlockerIssues')) || false;
         if (!shouldWriteIssues(response)) {

--- a/src/panels/WriteOffMenuPanel.ts
+++ b/src/panels/WriteOffMenuPanel.ts
@@ -237,29 +237,27 @@ class WriteOffMenuPanel {
 
             if (command === "webviewLoaded") {
                 logger.info('WriteOffMenuPanel: Webview loaded message received');
-                const historyId = yield this._storageManager.getLastScanHistoryId();
-                logger.info('WriteOffMenuPanel: Last scan history ID: ' + historyId);
-
-                let lastScanIssues = null;
-                if (historyId !== null) {
-                    lastScanIssues = yield this._storageManager.getLastScanIssuesFromHistoryId(historyId);
-                    logger.info('WriteOffMenuPanel: Issues retrieved: ' + (lastScanIssues ? lastScanIssues.length : 'No issues'));
-                    if (lastScanIssues && lastScanIssues.length > 0) {
-                        logger.info('WriteOffMenuPanel: First issue sample: ' + JSON.stringify(lastScanIssues[0], null, 2));
+                let issues = [];
+                try {
+                    const history = yield this._storageManager.getLivecheckHistory();
+                    if (Array.isArray(history)) {
+                        for (const entry of history) {
+                            const path = require('path');
+                            const fileName = entry.path ? path.basename(entry.path) : undefined;
+                            for (const issue of entry.issues || []) {
+                                issues.push(Object.assign(Object.assign({}, issue), { historyId: entry.id, historyPath: entry.path, fileName: issue.fileName || fileName }));
+                            }
+                        }
                     }
-                } else {
-                    logger.info('WriteOffMenuPanel: No history ID found');
                 }
-
-                // Create the data structure expected by the webview
-                const woData = {
-                    issues: lastScanIssues || [],
-                    historyId: historyId,
-                };
+                catch (e) {
+                    logger.warn('WriteOffMenuPanel: getLivecheckHistory failed: ' + (e === null || e === void 0 ? void 0 : e.message));
+                }
+                logger.info('WriteOffMenuPanel: Total issues retrieved: ' + issues.length);
+                const woData = { issues };
                 if (this._preselectIssue) {
                     woData.preselect = this._preselectIssue;
                 }
-
                 const responseData = { command: 'WOdata', data: JSON.stringify(woData) };
                 logger.info('WriteOffMenuPanel: Sending WOdata response: ' + JSON.stringify(responseData));
                 WriteOffMenuPanel.currentPanel._panel.webview.postMessage(responseData);

--- a/src/services/LocalStorageService.ts
+++ b/src/services/LocalStorageService.ts
@@ -112,7 +112,16 @@ class LocalStorageService {
                     });
                 }
                 if (row.issue_data) {
-                    historyMap.get(row.id).issues.push(JSON.parse(row.issue_data));
+                    const issue = JSON.parse(row.issue_data);
+                    try {
+                        const path = require('path');
+                        const fileName = row.path ? path.basename(row.path) : undefined;
+                        if (fileName && !issue.fileName) {
+                            issue.fileName = fileName;
+                        }
+                    }
+                    catch (_) { }
+                    historyMap.get(row.id).issues.push(issue);
                 }
             }
             stmt.free();
@@ -122,8 +131,10 @@ class LocalStorageService {
     setLivecheckHistory(path, issues, timestamp) {
         return __awaiter(this, void 0, void 0, function* () {
             const db = yield this.getDb();
+            db.run(`DELETE FROM Issues WHERE history_id IN (SELECT id FROM LivecheckHistory WHERE path = ?)`, [path]);
+            db.run(`DELETE FROM WriteOffData WHERE history_id IN (SELECT id FROM LivecheckHistory WHERE path = ?)`, [path]);
+            db.run(`DELETE FROM LivecheckHistory WHERE path = ?`, [path]);
             db.run(`INSERT INTO LivecheckHistory (path, timestamp) VALUES (?, ?)`, [path, timestamp]);
-            // Get last inserted id
             const stmt = db.prepare(`SELECT last_insert_rowid() as id`);
             stmt.step();
             const row = stmt.getAsObject();

--- a/src/services/MementoStorageService.ts
+++ b/src/services/MementoStorageService.ts
@@ -52,14 +52,16 @@ class MementoStorageService {
     setLivecheckHistory(path, issues, timestamp) {
         return __awaiter(this, void 0, void 0, function* () {
             const history = yield this.getLivecheckHistory();
-            const newId = history.length > 0 ? history[history.length - 1].id + 1 : 1;
-            history.push({
+            const filtered = history.filter(h => h.path !== path);
+            const maxId = filtered.reduce((max, h) => Math.max(max, h.id), 0);
+            const newId = maxId + 1;
+            filtered.push({
                 id: newId,
                 path,
                 timestamp,
                 issues,
             });
-            yield this.memento.update('LivecheckHistory', history);
+            yield this.memento.update('LivecheckHistory', filtered);
             return newId;
         });
     }

--- a/src/utilities/UpdateDiagnostics.ts
+++ b/src/utilities/UpdateDiagnostics.ts
@@ -15,10 +15,13 @@ const extension_1 = require("../extension");
 function updateDiagnostics(document, response, context, storageManager) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!document || !response) {
-            extension_1.collection.clear();
+            if (document) {
+                extension_1.collection.delete(document.uri);
+            }
             return;
         }
-        extension_1.collection.clear();
+        // Remove diagnostics only for the current document
+        extension_1.collection.delete(document.uri);
         const diagnosticsArray = [];
         const displayOnlyBlockerIssues = (yield storageManager.getUserData('OnlyBlockerIssues')) || false;
         if (!shouldWriteIssues(response)) {

--- a/webview-ui/src/App.js
+++ b/webview-ui/src/App.js
@@ -42,8 +42,6 @@ function App() {
     const [ruleFilter, setRuleFilter] = useState('');
     const [viewMode, setViewMode] = useState('single'); // 'bulk' or 'single'
     const [loading, setLoading] = useState(false);
-    const [historyId, setHistoryId] = useState(null);
-    const [historyPath, setHistoryPath] = useState(null);
 
     // Reference to the reason select element
     const reasonSelectRef = useRef(null);
@@ -84,12 +82,6 @@ function App() {
                             console.log('First issue sample:', data.issues[0]);
                         }
                         setIssues(data.issues || []);
-                        if (typeof data.historyId !== 'undefined') {
-                            setHistoryId(data.historyId);
-                        }
-                        if (typeof data.historyPath !== 'undefined') {
-                            setHistoryPath(data.historyPath);
-                        }
                         if (data.preselect) {
                             const { fileName, lineNumber } = data.preselect;
                             const match = (data.issues || []).find(
@@ -204,8 +196,8 @@ function App() {
             vscode.postMessage({
                 command: 'openFileAtLine',
                 data: {
-                    historyId,
-                    historyPath, // optional hint for backend
+                    historyId: issue.historyId,
+                    historyPath: issue.historyPath,
                     fileName: issue.fileName,
                     lineNumber: issue.lineNumber
                 }


### PR DESCRIPTION
## Summary
- keep diagnostics from previous files when running new live checks
- include file names with stored issues and expose all history entries to the write-off panel
- allow webview to open issues using per-file history metadata
- clear previous scan results for a file before recording new issues to avoid duplicates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5f9c741d88329b9779d68dc14ea65